### PR TITLE
Local OCI Registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#50bc655e3ec555f0a4c8e3f02cbfdd34c9734f79"
+source = "git+https://github.com/fermyon/conformance-tests#ca2d251be10929ddb0b7d2db195a4373afb2d5b0"
 dependencies = [
  "anyhow",
  "flate2",
@@ -7084,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#50bc655e3ec555f0a4c8e3f02cbfdd34c9734f79"
+source = "git+https://github.com/fermyon/conformance-tests#ca2d251be10929ddb0b7d2db195a4373afb2d5b0"
 dependencies = [
  "anyhow",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ dependencies = [
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#8549e0fa0cb7ed41263335cb895eb509c1b61a49"
+source = "git+https://github.com/fermyon/conformance-tests#50bc655e3ec555f0a4c8e3f02cbfdd34c9734f79"
 dependencies = [
  "anyhow",
  "flate2",
@@ -7084,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/conformance-tests#8549e0fa0cb7ed41263335cb895eb509c1b61a49"
+source = "git+https://github.com/fermyon/conformance-tests#50bc655e3ec555f0a4c8e3f02cbfdd34c9734f79"
 dependencies = [
  "anyhow",
  "fslock",


### PR DESCRIPTION
Use a local OCI registry in docker (deployed as a service) instead of relying on ttl.sh. 

This also updates the tests to run the key-value conformance test.